### PR TITLE
Add Azure Function with HTTP trigger

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,12 @@ jobs:
         inlineScript: |
            az cdn endpoint purge --content-paths  "/*" --profile-name ${{ secrets.CDN_PROFILE_NAME }} --name ${{ secrets.CDN_ENDPOINT_NAME }} --resource-group ${{ secrets.RESOURCE_GROUP }}
 
+    - name: Deploy Azure Function
+      uses: azure/CLI@v1
+      with:
+        inlineScript: |
+          az functionapp deployment source config-zip --resource-group ${{ secrets.RESOURCE_GROUP }} --name ${{ secrets.FUNCTION_APP_NAME }} --src-path function_app.zip
+
   # Azure logout
     - name: logout
       run: |

--- a/function_app/main.py
+++ b/function_app/main.py
@@ -1,0 +1,38 @@
+import os
+import json
+import logging
+import azure.functions as func
+from azure.cosmosdb.table.tableservice import TableService
+from azure.cosmosdb.table.models import Entity
+
+def main(req: func.HttpRequest) -> func.HttpResponse:
+    logging.info('Python HTTP trigger function processed a request.')
+
+    try:
+        # Get the connection string from environment variables
+        connection_string = os.environ['AzureWebJobsStorage']
+        
+        # Create the TableService object
+        table_service = TableService(connection_string=connection_string)
+        
+        # Read the entity with partition key '1' and row key 'counter'
+        entity = table_service.get_entity('YourTableName', '1', 'counter')
+        
+        # Increment the 'count' field by 1
+        entity['count'] += 1
+        
+        # Update the entity in the table
+        table_service.update_entity('YourTableName', entity)
+        
+        # Return a JSON response with the updated count
+        return func.HttpResponse(
+            json.dumps({'count': entity['count']}),
+            mimetype="application/json"
+        )
+    except Exception as e:
+        logging.error(f"An error occurred: {e}")
+        return func.HttpResponse(
+            json.dumps({'error': 'An error occurred while processing your request.'}),
+            status_code=500,
+            mimetype="application/json"
+        )


### PR DESCRIPTION
Add an Azure Function in Python with an HTTP trigger to connect to Azure CosmosDB, read, increment, and update an entity, and return a JSON response.

* **function_app/main.py**: 
  - Add a new Python file for the Azure Function.
  - Import necessary modules: `os`, `json`, `logging`, `azure.functions`, `azure.cosmosdb.table`.
  - Define the main function with an HTTP trigger.
  - Connect to Azure CosmosDB using the Table API.
  - Read the entity with partition key '1' and row key 'counter'.
  - Increment the 'count' field by 1 and update the entity in the table.
  - Return a JSON response with the updated count.
  - Handle exceptions and return a 500 error with an error message if something fails.

* **.github/workflows/main.yml**:
  - Add a step to deploy the Azure Function using Azure CLI.
  - Ensure the function app already exists and `AZURE_CREDENTIALS` secret is configured.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/alexdavis10/CloudResume/pull/1?shareId=89eca3b3-bfd3-4f35-88ff-bc847024a671).