### PR TITLE
Add visitor counter to resume website

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,3 +29,35 @@ jobs:
       run: |
             az logout
       if: always()
+
+  deploy_function_app:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - uses: actions/checkout@v3
+    - uses: azure/login@v2
+      with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+    - name: Deploy Bicep template
+      uses: azure/CLI@v1
+      with:
+        inlineScript: |
+          az deployment group create --resource-group CloudResume-Challenge-RG --template-file bicep/main.bicep
+
+    - name: Deploy Azure Function App
+      uses: azure/functions-action@v1
+      with:
+        app-name: cloud-resume-function-app
+        package: './function_app'
+
+    - name: Purge CDN endpoint
+      uses: azure/CLI@v1
+      with:
+        inlineScript: |
+           az cdn endpoint purge --content-paths  "/*" --profile-name "staticwebsite-cdn" --name "alex-cloud-resume" --resource-group "CloudResume-Challenge-RG"
+
+    - name: logout
+      run: |
+            az logout
+      if: always()

--- a/bicep/main.bicep
+++ b/bicep/main.bicep
@@ -1,0 +1,111 @@
+param location string = resourceGroup().location
+param functionAppName string
+param storageAccountName string
+param cosmosDbAccountName string
+param cosmosDbDatabaseName string
+param cosmosDbContainerName string
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2021-04-01' = {
+  name: storageAccountName
+  location: location
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+}
+
+resource functionApp 'Microsoft.Web/sites@2021-02-01' = {
+  name: functionAppName
+  location: location
+  kind: 'functionapp'
+  properties: {
+    serverFarmId: appServicePlan.id
+    siteConfig: {
+      appSettings: [
+        {
+          name: 'AzureWebJobsStorage'
+          value: storageAccount.properties.primaryEndpoints.blob
+        }
+        {
+          name: 'FUNCTIONS_EXTENSION_VERSION'
+          value: '~3'
+        }
+        {
+          name: 'WEBSITE_RUN_FROM_PACKAGE'
+          value: '1'
+        }
+        {
+          name: 'AzureCosmosDBConnectionString'
+          value: cosmosDbAccount.properties.connectionStrings[0].connectionString
+        }
+      ]
+    }
+  }
+}
+
+resource appServicePlan 'Microsoft.Web/serverfarms@2021-02-01' = {
+  name: 'appServicePlan'
+  location: location
+  sku: {
+    name: 'Y1'
+    tier: 'Dynamic'
+  }
+}
+
+resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2021-04-01' = {
+  name: cosmosDbAccountName
+  location: location
+  kind: 'GlobalDocumentDB'
+  properties: {
+    databaseAccountOfferType: 'Standard'
+    locations: [
+      {
+        locationName: location
+      }
+    ]
+    consistencyPolicy: {
+      defaultConsistencyLevel: 'Session'
+    }
+    capabilities: [
+      {
+        name: 'EnableTable'
+      }
+    ]
+  }
+}
+
+resource cosmosDbDatabase 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2021-04-01' = {
+  name: '${cosmosDbAccountName}/${cosmosDbDatabaseName}'
+  location: location
+  properties: {
+    resource: {
+      id: cosmosDbDatabaseName
+    }
+  }
+  dependsOn: [
+    cosmosDbAccount
+  ]
+}
+
+resource cosmosDbContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2021-04-01' = {
+  name: '${cosmosDbAccountName}/${cosmosDbDatabaseName}/${cosmosDbContainerName}'
+  location: location
+  properties: {
+    resource: {
+      id: cosmosDbContainerName
+      partitionKey: {
+        paths: ['/partitionKey']
+        kind: 'Hash'
+      }
+    }
+  }
+  dependsOn: [
+    cosmosDbDatabase
+  ]
+}
+
+output functionAppName string = functionApp.name
+output storageAccountName string = storageAccount.name
+output cosmosDbAccountName string = cosmosDbAccount.name
+output cosmosDbDatabaseName string = cosmosDbDatabase.name
+output cosmosDbContainerName string = cosmosDbContainer.name

--- a/function_app/main.py
+++ b/function_app/main.py
@@ -1,0 +1,33 @@
+import logging
+import azure.functions as func
+import os
+from azure.cosmosdb.table.tableservice import TableService
+from azure.cosmosdb.table.models import Entity
+
+def main(req: func.HttpRequest) -> func.HttpResponse:
+    logging.info('Python HTTP trigger function processed a request.')
+
+    # Retrieve the connection string from environment variables
+    connection_string = os.getenv('AzureWebJobsStorage')
+    table_service = TableService(connection_string=connection_string)
+    table_name = 'VisitorCount'
+
+    # Check if the table exists, if not create it
+    if not table_service.exists(table_name):
+        table_service.create_table(table_name)
+
+    # Retrieve the visitor count entity
+    visitor_count_entity = table_service.get_entity(table_name, '1', '1')
+
+    # Update the visitor count
+    visitor_count = int(visitor_count_entity['count'])
+    visitor_count += 1
+    visitor_count_entity['count'] = visitor_count
+    table_service.update_entity(table_name, visitor_count_entity)
+
+    # Return the updated visitor count
+    return func.HttpResponse(
+        body=f'{{"count": {visitor_count}}}',
+        status_code=200,
+        mimetype="application/json"
+    )

--- a/function_app/requirements.txt
+++ b/function_app/requirements.txt
@@ -1,0 +1,2 @@
+azure-functions
+azure-cosmosdb-table

--- a/index.html
+++ b/index.html
@@ -232,6 +232,18 @@
    <script src="js/jquery.magnific-popup.min.js"></script>
    <script src="js/init.js"></script>
    <script src="js/main.js"></script>
+   <script>
+      document.addEventListener("DOMContentLoaded", function() {
+         fetch("https://<your-function-app-name>.azurewebsites.net/api/visitorCount")
+            .then(response => response.json())
+            .then(data => {
+               const visitorCountElement = document.createElement("p");
+               visitorCountElement.textContent = `Visitor Count: ${data.count}`;
+               document.body.appendChild(visitorCountElement);
+            })
+            .catch(error => console.error("Error fetching visitor count:", error));
+      });
+   </script>
 
 </body>
 </html>

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,40 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import azure.functions as func
+import main
+
+class TestFunction(unittest.TestCase):
+    @patch('main.TableService')
+    @patch('main.os.getenv')
+    def test_visitor_count(self, mock_getenv, mock_table_service):
+        # Mock environment variable
+        mock_getenv.return_value = 'fake_connection_string'
+
+        # Mock TableService
+        mock_table_service_instance = MagicMock()
+        mock_table_service.return_value = mock_table_service_instance
+
+        # Mock entity
+        mock_entity = {'count': '1'}
+        mock_table_service_instance.get_entity.return_value = mock_entity
+
+        # Create a mock HTTP request
+        req = func.HttpRequest(
+            method='GET',
+            url='/api/visitorCount',
+            body=None
+        )
+
+        # Call the function
+        resp = main.main(req)
+
+        # Check the response
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.get_body().decode(), '{"count": 2}')
+
+        # Check if the entity was updated
+        updated_entity = {'count': 2}
+        mock_table_service_instance.update_entity.assert_called_once_with('VisitorCount', updated_entity)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Implement a visitor counter for the static HTML resume website using Azure Functions and Azure Cosmos DB.

* **Azure Function App**: Add `function_app/main.py` to handle HTTP requests and update the visitor count in Azure Cosmos DB.
* **JavaScript Frontend**: Update `index.html` to include JavaScript code that calls the Azure Function API on page load and displays the visitor count.
* **Infrastructure as Code**: Add `bicep/main.bicep` to provision the Azure Function App, Cosmos DB, and required permissions.
* **CI/CD Pipeline**: Update `.github/workflows/main.yml` to include steps for deploying the Azure Function App, deploying the Bicep template, and purging the Azure CDN cache after front-end deployment.
* **Dependencies**: Add `function_app/requirements.txt` to include the required Python packages for the Azure Function App.
* **Testing**: Add `tests/test_main.py` to implement test cases for the HTTP trigger function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/alexdavis10/CloudResume/pull/2?shareId=a393c23a-1a9d-4a10-9fae-321b98018e60).